### PR TITLE
Solving duplicated paths in nested lists comparison.

### DIFF
--- a/src/EntityChange/EntityComparer.cs
+++ b/src/EntityChange/EntityComparer.cs
@@ -270,7 +270,7 @@ namespace EntityChange
             if (valueFactory == null)
                 throw new ArgumentNullException(nameof(valueFactory));
 
-            var currentPath = CurrentPath();
+            var currentPath = _pathStack.Peek();
 
             var orginalCount = originalList != null ? countFactory(originalList) : 0;
             var currentCount = currentList != null ? countFactory(currentList) : 0;

--- a/test/EntityChange.Tests/EntityCompareTests.cs
+++ b/test/EntityChange.Tests/EntityCompareTests.cs
@@ -984,6 +984,54 @@ namespace EntityChange.Tests
             WriteMarkdown(changes);
         }
 
+        [Fact]
+        public void ComparenNestedObjectsPathsTest()
+        {
+            var node = new TreeNode
+            {
+                Name = "Root",
+                nodes = new List<TreeNode>
+                {
+                    new TreeNode
+                    {
+                        Name = "Level 1",
+                        nodes = new List<TreeNode>
+                        {
+                            new TreeNode
+                            {
+                                Name = "Level 2"
+                            }
+                        }
+                    }
+                }
+            };
+
+            var node2 = new TreeNode
+            {
+                Name = "Root",
+                nodes = new List<TreeNode>
+                {
+                    new TreeNode
+                    {
+                        Name = "Level 1",
+                        nodes = new List<TreeNode>
+                        {
+                            new TreeNode
+                            {
+                                Name = "Level 3"
+                            }
+                        }
+                    }
+                }
+            };
+
+            EntityComparer entityComparer = new EntityComparer();
+            var changes = entityComparer.Compare(node, node2);
+
+            changes.Should().NotBeEmpty();
+            changes.First().Path.Should().Be("nodes[0].nodes[0].Name");
+        }
+
 
 
         private void WriteMarkdown(ReadOnlyCollection<ChangeRecord> changes)

--- a/test/EntityChange.Tests/Models/TreeNode.cs
+++ b/test/EntityChange.Tests/Models/TreeNode.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EntityChange.Tests.Models
+{
+    public class TreeNode
+    {
+        public List<TreeNode> nodes { get; set; }
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
Solving #5.

We traced the error back to the `CompareByIndexer<T>` method, which was incorrectly adding the full path every time.

Added a simple test for this fix.