### PR TITLE
Fixing value type root element comparison

### DIFF
--- a/src/EntityChange/EntityComparer.cs
+++ b/src/EntityChange/EntityComparer.cs
@@ -270,7 +270,7 @@ namespace EntityChange
             if (valueFactory == null)
                 throw new ArgumentNullException(nameof(valueFactory));
 
-            var currentPath = _pathStack.Peek();
+            var currentPath = CurrentPath();
 
             var orginalCount = originalList != null ? countFactory(originalList) : 0;
             var currentCount = currentList != null ? countFactory(currentList) : 0;
@@ -343,10 +343,9 @@ namespace EntityChange
             var currentKeys = currentDictionary != null 
                 ? keysFactory(currentDictionary).Cast<object>().ToList()
                 : new List<object>();
-
-
+            
             var currentPath = CurrentPath();
-
+            
             // compare common keys
             var commonKeys = originalKeys.Intersect(currentKeys).ToList();
             _pathStack.Pop();

--- a/src/EntityChange/EntityComparer.cs
+++ b/src/EntityChange/EntityComparer.cs
@@ -428,10 +428,10 @@ namespace EntityChange
         {
             var currentMember = CurrentMember();
             var propertyName = name ?? CurrentName();
-            var displayName = currentMember.DisplayName ?? propertyName.ToSpacedWords();
+            var displayName = currentMember?.DisplayName ?? propertyName.ToSpacedWords();
             var currentPath = path ?? CurrentPath();
-            var originalFormatted = FormatValue(original, currentMember.Formatter);
-            var currentFormatted = FormatValue(current, currentMember.Formatter);
+            var originalFormatted = FormatValue(original, currentMember?.Formatter);
+            var currentFormatted = FormatValue(current, currentMember?.Formatter);
 
             var changeRecord = new ChangeRecord
             {

--- a/test/EntityChange.Tests/EntityCompareTests.cs
+++ b/test/EntityChange.Tests/EntityCompareTests.cs
@@ -1048,6 +1048,21 @@ namespace EntityChange.Tests
             changeRecord.CurrentValue.Should().Be(2);
         }
         
+        [Fact]
+        public void CompareArrayRootElementsTest()
+        {
+            TreeNode[] original = new TreeNode[] { new TreeNode { Name = "Level 1" } };
+            TreeNode[] current = new TreeNode[] { };
+
+            EntityComparer entityComparer = new EntityComparer();
+            ReadOnlyCollection<ChangeRecord> changes = entityComparer.Compare(original, current);
+
+            changes.Should().NotBeEmpty();
+
+            ChangeRecord changeRecord = changes.First();
+            changeRecord.Path.Should().Be("[0]");
+        }
+        
         private void WriteMarkdown(ReadOnlyCollection<ChangeRecord> changes)
         {
             var formatter = new MarkdownFormatter();

--- a/test/EntityChange.Tests/EntityCompareTests.cs
+++ b/test/EntityChange.Tests/EntityCompareTests.cs
@@ -1031,9 +1031,23 @@ namespace EntityChange.Tests
             changes.Should().NotBeEmpty();
             changes.First().Path.Should().Be("nodes[0].nodes[0].Name");
         }
+        
+        [Fact]
+        public void CompareValueTypeRootElementsTest()
+        {
+            int original = 1;
+            int current = 2;
+            
+            var entityComparer = new EntityComparer();
+            var changes = entityComparer.Compare(original, current);
+            
+            changes.Should().NotBeEmpty();
 
-
-
+            ChangeRecord changeRecord = changes.First();
+            changeRecord.OriginalValue.Should().Be(1);
+            changeRecord.CurrentValue.Should().Be(2);
+        }
+        
         private void WriteMarkdown(ReadOnlyCollection<ChangeRecord> changes)
         {
             var formatter = new MarkdownFormatter();


### PR DESCRIPTION
Solving #8.

Added the safe navigation operator to the affected instructions by the bug, so the exception isn't thrown anymore.

Also, added a test to check if the implementation was correct.